### PR TITLE
[agent_farm] the bottom banner with the blog and codestory logo overlaps with the content of the webpage (Run ID: codestoryai_website_issue_70_05c2621a)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -73,13 +73,15 @@ export default async function RootLayout({
             lang="en"
             suppressHydrationWarning={true}
         >
-            <body>
+            <body className="min-h-screen flex flex-col">
                 <PHProvider>
                     <PostHogPageView />
                     <TooltipProvider delayDuration={0}>
                         <Impersonation />
                         <Header />
-                        {children}
+                        <main className="flex-grow">
+                            {children}
+                        </main>
                         <Footer />
                     </TooltipProvider>
                 </PHProvider>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -15,7 +15,7 @@ export default function Footer() {
     const isBlogPost = pathname.startsWith("/blog/");
 
     return (
-        <footer className="absolute bottom-0 left-0 right-0 bg-[#0F1729] p-8 text-sm md:p-12">
+        <footer className="bg-[#0F1729] p-8 text-sm md:p-12">
             <div className="m-auto flex max-w-screen-xl flex-col gap-5">
                 <div className="grid justify-center gap-8 md:grid-cols-3 md:justify-normal md:text-lg">
                     <div className="flex justify-center gap-8 md:justify-start">


### PR DESCRIPTION
agent_instance: codestoryai_website_issue_70_05c2621a Tries to fix: #70

🛠️ **Fix:** Resolved footer overlap issue with proper sticky footer implementation

- **Updated:** Removed absolute positioning from footer component
- **Added:** Flex layout system with `flex-grow` main content to ensure footer stays at bottom
- **Modified:** Layout structure in both footer and root layout components

Please review these changes to ensure the footer now displays correctly without content overlap. 👀